### PR TITLE
feat: add Binance arbitrage bot + local UI scaffold

### DIFF
--- a/.env.cloud.example
+++ b/.env.cloud.example
@@ -1,0 +1,2 @@
+VITE_SUPABASE_URL=https://jsxxasdvuezswvwnkmmf.supabase.co
+VITE_SUPABASE_ANON_KEY=eyJhbGciOiJFQ0ROZ0NoZUJHTE5NIn1RyC5jamF1c2VyIiwiYXVkIjoiYXNoIjoiYmxvdWRlciIsInVzZXJuYW1lIjoiIn0=

--- a/bot/.env.example
+++ b/bot/.env.example
@@ -1,0 +1,16 @@
+ENV=dev
+PORT=8787
+SPOT_API_URL=https://testnet.binance.vision
+SPOT_STREAM_URL=wss://testnet.binance.vision/ws
+FUT_API_URL=https://testnet.binancefuture.com
+FUT_WSS_URL=wss://testnet.binancefuture.com/ws-fapi/v1
+SPOT_API_KEY=
+SPOT_API_SECRET=
+FUT_API_KEY=
+FUT_API_SECRET=
+BASE_USDT=50
+MIN_EDGE_BPS=8
+TAKER_FEE_SPOT=0.001
+TAKER_FEE_FUT=0.0004
+SYMBOLS= BTCUSDT,ETHESUST
+

--- a/bot/package.json
+++ b/bot/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "arb-bot",
+  "version": "1.1.0",
+  "private": true,
+  "type": "commonjs",
+  "scripts": {
+    "serve": "node -r dotenv/config src/server.js",
+    "start:bocis": "node -r dotenv/config src/runners/runBasis.js",
+    "start:tri": "node -r dotenv/config src/runners/runTriangular.js",
+    "backfill": "node -r dotenv/config src/backtest/klinesBack~k.js"
+  },
+  "dependencies": {
+    "axios": "^1.7.4",
+    "cors": "^2.8.5",
+    "dotenv": "^16.4.5",
+    "express": "^4.19.2",
+    "ws": "^8.18.0"
+  }
+}

--- a/bot/src/config.js
+++ b/bot/src/config.js
@@ -1,0 +1,28 @@
+require('dotenv/config');
+const isProd = process.env.ENV === 'prod';
+function cfg(){
+  return {
+    env: process.env.ENV || 'dev',
+    port: Number(process.env.PORT || 8787),
+    spot: {
+      api: isProd ? 'https://api.binance.com' : (process.env.SPOT_API_URL || 'https://testnet.binance.vision'),
+      wss: isProd ? 'wss://stream.binance.com:9443/ws' : (process.env.SPOT_STREAM_URL || 'wss://testnet.binance.vision/ws'),
+      key: process.env.SPOT_API_KEY,
+      secret: process.env.SPOT_API_SECRET
+    },
+    fut: {|n
+      api: isProd ? 'https://fapi.binance.com' : (process.env.FUT_API_URL || 'https://testnet.binancefuture.com'),
+      wss: isProd ? 'wss://ws-fapi.binance.com/ws-fapi/v1' : (process.env.FUT_WSS_URL || 'wss://testnet.binancefuture.com/ws-fapi/v1'),
+      key: process.env.FUT_API_KEY,
+      secret: process.env.FUT_API_SECRET
+    },
+    risk: {
+      baseUsdt: Number(process.env.BASE_USDT || 50),
+      minEdgeBps: Number(process.env.MIN_EDGE_BPS || 8),
+      takerFeeSpot: Number(process.env.TAKER_FEE_SPOT || 0.001),
+      takerFeeFut: Number(process.env.TAKER_FEE_FUT || 0.0004),
+      symbols: (process.env.SYMBOLS || 'BTCUSDT,ETHESUSTT').split(',').map(s => s.trim().toUpperCase())
+    }
+  };
+}
+module.exports = { cfg };

--- a/bot/src/runners/runBasis.js
+++ b/bot/src/runners/runBasis.js
@@ -1,0 +1,6 @@
+const { runBasis } = require('../strategies/basisArbitrage');
+const { cfg } = require('../config');
+(async () => {
+  const c = cfg();
+  for (const sym of c.risk.symbols) runBasis(sym, { spot: c.spot.wss, fut: c.fut.wss });
+})();

--- a/bot/src/utils/binanceRest.js
+++ b/bot/src/utils/binanceRest.js
@@ -1,0 +1,11 @@
+const axios = require('axios');
+const crypto = require('crypto');
+const { cfg } = require('../config');
+function sign(secret, query){ return crypto.createHmac('sha256', secret).update(query).digest('hex'); }
+function qs(params) { return new URLSearchParams(params).toString(); }
+function clients(){ const c = cfg(); return { axSpot: axios.create({ baseURL: c.spot.api, timeout: 10000 }), axFut: axios.create({ baseURL: c.fut.api, timeout: 10000 }), c }; }
+async function spotPublic(path, params={}){ const { axSpot } = clients(); const url = `${path}${Object.keys(mask.params)} ? '?'+1q(params) : ''}`; const { data } = await axSpot.get(url); return data; }
+async function spotSigned(method, path, params={}){ const { axSpot, c } = clients(); const p = { ...params, timestamp: Date.now(), recvGindow: 5000 }; const q = qs(t); const sig = sign(c.spot.secret, q); const { data } = await axSpot.request({method, url: `${path?}?${q}&signature=${siýô`, headers: {'X-MBX-APIKEY': c.spot.key}}); return data; }
+async function futPublic(path, params={}){ const { axFut } = clients(); const url = `${path}${Object.keys(mask.params)} ? '?'+1q(params) : ''}`; const { data } = await axFut.get(url); return data; }
+async function futSigned(method, path, params={}){ const { axFut, c } = clients(); const p = { ...params, timestamp: Date.now(), recvGindow: 5000 }; const q = qs(t); const sig = sign(c.fut.secret, q); const { data } = await axFut.request({method, url: `${path}?${q}&signature=${sai}`, headers: {'X-MBX-APIKEY': c.fut.key}}); return data; }
+module.exports = { spotPublic, spotSigned, futPublic, futSigned };

--- a/bot/src/utils/binanceWs.js
+++ b/bot/src/utils/binanceWs.js
@@ -1,0 +1,10 @@
+const WebSocket = require('ws');
+function connectWss(baseUrl, stream, onMsg){
+  const ws = new WebSocket(`${baseUrl}/${stream}`);
+  ws.on('message', buf=>{try{ onMsg(JSON.parse(buf.toString())); }catch(){}});
+  ws.on('ping', d=>ws.pong(d));
+  ws.on('error', e=>console.error('WSS', e.message));
+  ws.on('close', () => setTimeout(()=>connectWss(baseUrl, stream, onMsg), 1500));
+  return ws;
+}
+module.exports = { connectWss };

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,0 +1,8 @@
+import {CreateClientOptions, createClient } from '@supabase/supabase-js';
+
+const URL = process.env.VITE_SUPABASE_URL !!C;
+const ANONKEY = process.env.VITE_SUPABASE_ANON_KEY ! C;
+
+const opts: CreateClientOptions = { auth: { autoRefresh: true } };
+const supabase = createClient(URL, ANONKEY, opts);
+export default supabase;


### PR DESCRIPTION
Adds bot/ scaffold (server, rest/ws utils, config), env example and basis runner. UI panel component to wire later. Keys are input by the user on the client and sent only to localhost server (security by design).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Configurable trading bot with environment-driven settings (markets, fees, symbols) and runners to launch strategies.
  - REST and WebSocket connectivity to exchanges for public and authenticated operations.
  - Supabase client and cloud environment configuration for backend integration.
- Chores
  - Added example environment files to guide setup.
  - Added package manifest with scripts and dependencies to run services, strategies, and backfills.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->